### PR TITLE
Server error in generate-error endpoint:

### DIFF
--- a/app/api/generate-error/route.ts
+++ b/app/api/generate-error/route.ts
@@ -22,7 +22,7 @@ function indexError(): number {
 
 function asyncError(): string {
   const fetchData = async () => 'async data';
-  const result = fetchData(); // Missing await - returns Promise<string> not string
+  const result = await fetchData(); // Missing await - returns Promise<string> not string
   // @ts-ignore
   return result.toUpperCase(); // Property 'toUpperCase' does not exist on type 'Promise<string>'
 }


### PR DESCRIPTION
Attempted to fix: Server error in generate-error endpoint: TypeError: (intermediate value)(...).toUpperCase is not a function
    at v (.next/server/app/api/generate-error/route.js:1:1709)
    at async k (.next/server/app/api/generate-error/route.js:1:4620)
    at async g (.next/server/app/api/generate-error/route.js:1:5623)
    at async B (.next/server/app/api/generate-error/route.js:1:6745)

Generated by automated fix for log ID: 34794840670175505389593766000000